### PR TITLE
Lower PHP Requirement to 7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
 
     strategy:
       matrix:
-        operating-system: [ubuntu-latest]
-        php-versions: ['7.3', '7.4', '8.0']
+        operating-system: [ ubuntu-latest ]
+        php-versions: [ '7.2','7.3', '7.4', '8.0' ]
 
     runs-on: ${{ matrix.operating-system }}
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Utilities for working with [PSR-7 Http Message](https://www.php-fig.org/psr/psr-
 ## Requirements
 
 - **psr/http-message**: ^1.0
-- **php**: >=7.3
+- **php**: >=7.2
 
 ## Installing
 

--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
 	"type": "library",
 	"require": {
 		"psr/http-message": "^1.0",
-		"php": ">=7.3"
+		"php": ">=7.2"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^9.5",
+		"phpunit/phpunit": "^6.5 || ^9.3",
 		"php-mock/php-mock-phpunit": "^2.6",
 		"guzzlehttp/psr7": "^1.8",
 		"corpus/coding-standard": "^0.3.0",


### PR DESCRIPTION
I probably don't actually need 7.3 and 7.2 allows a broader spectrum of users.