### PR TITLE
ResponseSender - Replace default headers

### DIFF
--- a/src/ResponseSender.php
+++ b/src/ResponseSender.php
@@ -62,12 +62,17 @@ class ResponseSender {
 			http_response_code($response->getStatusCode());
 		}
 
+		$sentHeaders = [];
 		foreach( $response->getHeaders() as $name => $values ) {
 			foreach( $values as $value ) {
+				$lower = strtolower($name);
+
 				header(
 					sprintf("%s: %s", $name, $value),
-					false
+					!isset($sentHeaders[$lower])
 				);
+
+				$sentHeaders[$lower] = true;
 			}
 		}
 


### PR DESCRIPTION
As written, ResponseSender would not overwrite default headers, which was extremely limiting for cases of things such as cache headers and `X-Powered-By`

This changes the default behaviour to overwrite default headers